### PR TITLE
feat(deployment): Add required capabilities so that nucleus could deserialize the field

### DIFF
--- a/src/main/java/com/amazon/aws/iot/greengrass/configuration/common/Configuration.java
+++ b/src/main/java/com/amazon/aws/iot/greengrass/configuration/common/Configuration.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Data
@@ -52,6 +53,9 @@ public class Configuration {
     @Builder.Default
     private ConfigurationValidationPolicy configurationValidationPolicy = ConfigurationValidationPolicy.builder()
             .build();
+
+    // Enum can't be used because values are expected to be expanded and the field should always be de-serializable
+    private List<String> requiredCapabilities;
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class ConfigurationBuilder {

--- a/src/test/java/com/amazon/aws/iot/greengrass/configuration/common/ConfigurationDeserializationTest.java
+++ b/src/test/java/com/amazon/aws/iot/greengrass/configuration/common/ConfigurationDeserializationTest.java
@@ -18,13 +18,16 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.IsEqual.equalTo;
 
 class ConfigurationDeserializationTest extends BaseConfigurationTest {
 
@@ -50,6 +53,20 @@ class ConfigurationDeserializationTest extends BaseConfigurationTest {
                 new String(Files.readAllBytes(configurationPath)), Configuration.class);
 
         verifyConfiguration1ComponentReplace(configuration);
+        assertThat(configuration.getRequiredCapabilities(), is(null));
+    }
+
+    @Test
+    void GIVEN_configuration_1_required_capabilities_THEN_return_instantiated_model_instance() throws IOException {
+        String filename = "configuration-1-with-required-capabilities.json";
+        Path configurationPath = getResourcePath(filename);
+
+        Configuration configuration = DESERIALIZER_JSON.readValue(
+                new String(Files.readAllBytes(configurationPath)), Configuration.class);
+
+        verifyConfiguration1ComponentReplace(configuration);
+        assertThat(configuration.getRequiredCapabilities(), equalTo(Arrays.asList("LARGE_CONFIGURATION",
+                "ANOTHER_CAPABILITY")));
     }
 
     void verifyConfiguration1ComponentReplace(final Configuration configuration) throws JsonProcessingException {

--- a/src/test/java/com/amazon/aws/iot/greengrass/configuration/common/ConfigurationSerializationTest.java
+++ b/src/test/java/com/amazon/aws/iot/greengrass/configuration/common/ConfigurationSerializationTest.java
@@ -30,4 +30,19 @@ class ConfigurationSerializationTest extends BaseConfigurationTest {
 
         assertThat(copy, Is.is(original));
     }
+
+    @Test
+    void GIVEN_deploy_1_component_required_capabilities_WHEN_we_deserialize_it_and_serialize_it_back_THEN_we_get_the_same_thing()
+            throws IOException {
+        String filename = "configuration-1-with-required-capabilities.json";
+        Path configurationPath = getResourcePath(filename);
+
+        Configuration original = DESERIALIZER_JSON.readValue(
+                new String(Files.readAllBytes(configurationPath)), Configuration.class);
+
+        Configuration copy = DESERIALIZER_JSON.readValue(
+                DESERIALIZER_JSON.writeValueAsString(original), Configuration.class);
+
+        assertThat(copy, Is.is(original));
+    }
 }

--- a/src/test/resources/configurations/configuration-1-with-required-capabilities.json
+++ b/src/test/resources/configurations/configuration-1-with-required-capabilities.json
@@ -1,0 +1,43 @@
+{
+  "requiredCapabilities": ["LARGE_CONFIGURATION", "ANOTHER_CAPABILITY"],
+  "components": {
+    "MyThermostatComponent": {
+      "version": "1.0.0",
+      "configurationUpdate": {
+        "MERGE": {
+          "units": "C",
+          "rooms": {
+            "Kitchen": {
+              "temperature": 25,
+              "fan": "on"
+            },
+            "Office": {
+              "temperature": 22,
+              "fan": "auto"
+            },
+            "Conference Room": {
+              "temperature": 20,
+              "fan": "auto"
+            }
+          }
+        },
+        "RESET": [
+          "/rooms/Kitchen",
+          "/rooms/Office",
+          "/rooms/Conference Room"
+        ]
+      },
+      "runWith": {
+        "posixUser": "user:group"
+      }
+    }
+  },
+  "failureHandlingPolicy": "DO_NOTHING",
+  "componentUpdatePolicy": {
+    "timeout": "5000",
+    "action": "SKIP_NOTIFY_COMPONENTS"
+  },
+  "configurationValidationPolicy": {
+    "timeout": "30000"
+  }
+}


### PR DESCRIPTION
**Description of changes:**
In order to support controllable errors, the GGC will support a requiredCapabilities element in the deployment document that describes capabilities needed to execute the deployment. If the required capability is not found, Nucleus will fail the deployment.

**Why is this change necessary:**
Need for https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/924

**How was this change tested:**
unit test added in this repo.
integration test added in nucleus repo.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
