### PR TITLE
feat(sub-group deploy): add root & base target fields

### DIFF
--- a/src/main/java/com/amazon/aws/iot/greengrass/configuration/common/Configuration.java
+++ b/src/main/java/com/amazon/aws/iot/greengrass/configuration/common/Configuration.java
@@ -41,6 +41,10 @@ public class Configuration {
 
     private String configurationArn;
 
+    private String parentTargetArn;
+
+    private String onBehalfOf;
+
     private Long creationTimestamp;
 
     @NonNull

--- a/src/test/java/com/amazon/aws/iot/greengrass/configuration/common/ConfigurationDeserializationTest.java
+++ b/src/test/java/com/amazon/aws/iot/greengrass/configuration/common/ConfigurationDeserializationTest.java
@@ -51,7 +51,11 @@ public class ConfigurationDeserializationTest extends BaseConfigurationTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"configuration-1-component-replace.json", "configuration-2-component-replace.json"})
+    @ValueSource(strings = {
+            "configuration-1-component-replace.json",
+            "configuration-2-component-replace.json",
+            "configuration-1-redeploy.json"
+    })
     void GIVEN_configuration_1_component_replace_THEN_return_instantiated_model_instance(String filename) throws IOException {
         Path configurationPath = getResourcePath(filename);
 

--- a/src/test/java/com/amazon/aws/iot/greengrass/configuration/common/ConfigurationSerializationTest.java
+++ b/src/test/java/com/amazon/aws/iot/greengrass/configuration/common/ConfigurationSerializationTest.java
@@ -19,7 +19,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 class ConfigurationSerializationTest extends BaseConfigurationTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"configuration-1-component-replace.json", "configuration-2-component-replace.json"})
+    @ValueSource(strings = {
+            "configuration-1-component-replace.json",
+            "configuration-2-component-replace.json",
+            "configuration-1-redeploy.json"
+    })
     void GIVEN_deployment_config_WHEN_deserialized_and_serialized_THEN_return_orig_config(String filename)
             throws IOException {
         Path configurationPath = getResourcePath(filename);

--- a/src/test/resources/configurations/configuration-1-redeploy.json
+++ b/src/test/resources/configurations/configuration-1-redeploy.json
@@ -1,0 +1,44 @@
+{
+  "components": {
+    "MyThermostatComponent": {
+      "version": "1.0.0",
+      "configurationUpdate": {
+        "MERGE": {
+          "units": "C",
+          "rooms": {
+            "Kitchen": {
+              "temperature": 25,
+              "fan": "on"
+            },
+            "Office": {
+              "temperature": 22,
+              "fan": "auto"
+            },
+            "Conference Room": {
+              "temperature": 20,
+              "fan": "auto"
+            }
+          }
+        },
+        "RESET": [
+          "/rooms/Kitchen",
+          "/rooms/Office",
+          "/rooms/Conference Room"
+        ]
+      },
+      "runWith": {
+        "posixUser": "user:group"
+      }
+    }
+  },
+  "failureHandlingPolicy": "DO_NOTHING",
+  "componentUpdatePolicy": {
+    "timeout": "5000",
+    "action": "SKIP_NOTIFY_COMPONENTS"
+  },
+  "configurationValidationPolicy": {
+    "timeout": "30000"
+  },
+  "onBehalfOf": "arn:aws:iot:us-east-1:123456789012:thinggroup/parentGroup",
+  "parentTargetArn": "arn:aws:iot:us-east-1:123456789012:thinggroup/parentGroup"
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Add baseTargetArn and rootTargetArn fields in deployment configuration to support sub-group deployments

**Why is this change necessary:**

**How was this change tested:**
Added redploy configuration in the test resources with new fields to validate current suite.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
