### PR TITLE
chore: set final name for output jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         </pluginRepository>
     </pluginRepositories>
     <build>
+        <finalName>${jar.name}</finalName>
         <extensions>
             <extension>
                 <groupId>fi.yle.tools</groupId>
@@ -133,6 +134,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <jar.name>aws.greengrass.component.common</jar.name>
     </properties>
     <distributionManagement>
         <snapshotRepository>


### PR DESCRIPTION
**Issue #, if available:**
CODEX-34580

**Description of changes:**
set `finalName` property to create `aws.greengrass.component.common.jar`

**Why is this change necessary:**
We want to create an output jar we can reference regardless of version number. This jar will be referenced internally to automate pulling in changes from this repo. Setting the `finalName` property does not change how maven installs or deploys package, only the resulting output jar file in the target folder.

**How was this change tested:**
`mvn package` created `target/aws.greengrass.component.common.jar` 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
