### PR TITLE
feat(recipe-schema): add json recipe schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,12 @@
             <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>1.0.87</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <pluginRepositories>
         <pluginRepository>

--- a/src/main/resources/recipe/recipe_schema.json
+++ b/src/main/resources/recipe/recipe_schema.json
@@ -1,0 +1,569 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "The AWS IoT Greengrass v2 recipe schema",
+  "default": {
+    "recipeformatversion": "2020-01-25",
+    "componentname": "com.example.hello",
+    "componentpublisher": "Me",
+    "componentversion": "1.0.0",
+    "manifests": [
+      {
+        "Lifecycle": {
+          "run": "echo Hello"
+        }
+      }
+    ]
+  },
+  "examples": [],
+  "required": [
+    "recipeformatversion",
+    "componentname",
+    "componentversion",
+    "manifests"
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "permissions": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "OWNER",
+        "ALL"
+      ]
+    },
+    "lifecycle": {
+      "type": "object",
+      "properties": {
+        "setenv": {
+          "$ref": "#/definitions/setenv"
+        },
+        "bootstrap": {
+          "$ref": "#/definitions/lifecycleElement"
+        },
+        "install": {
+          "$ref": "#/definitions/lifecycleElement"
+        },
+        "startup": {
+          "$ref": "#/definitions/lifecycleElement"
+        },
+        "run": {
+          "$ref": "#/definitions/lifecycleElement"
+        },
+        "shutdown": {
+          "$ref": "#/definitions/lifecycleElement"
+        },
+        "recover": {
+          "$ref": "#/definitions/lifecycleElement"
+        }
+      }
+    },
+    "baseLifecycle": {
+      "type": "object",
+      "properties": {
+        "setenv": {
+          "$ref": "#/definitions/setenv"
+        },
+        "bootstrap": {
+          "$ref": "#/definitions/baseLifecycleElement"
+        },
+        "install": {
+          "$ref": "#/definitions/baseLifecycleElement"
+        },
+        "startup": {
+          "$ref": "#/definitions/baseLifecycleElement"
+        },
+        "run": {
+          "$ref": "#/definitions/baseLifecycleElement"
+        },
+        "shutdown": {
+          "$ref": "#/definitions/baseLifecycleElement"
+        },
+        "recover": {
+          "$ref": "#/definitions/baseLifecycleElement"
+        }
+      }
+    },
+    "globalLifecycle": {
+      "type": "object",
+      "properties": {
+        "setenv": {
+          "$ref": "#/definitions/setenv"
+        },
+        "bootstrap": {
+          "$ref": "#/definitions/globalLifecycleElement"
+        },
+        "install": {
+          "$ref": "#/definitions/globalLifecycleElement"
+        },
+        "startup": {
+          "$ref": "#/definitions/globalLifecycleElement"
+        },
+        "run": {
+          "$ref": "#/definitions/globalLifecycleElement"
+        },
+        "shutdown": {
+          "$ref": "#/definitions/globalLifecycleElement"
+        },
+        "recover": {
+          "$ref": "#/definitions/globalLifecycleElement"
+        }
+      }
+    },
+    "globalLifecycleElement": {
+      "$ref": "#/definitions/lifecycleElement",
+      "properties": {
+        "script": {
+          "$ref": "#/definitions/selections"
+        }
+      }
+    },
+    "lifecycleElement": {
+      "anyOf": [
+        {
+          "allOf": [
+            {
+              "$ref": "#/definitions/baseLifecycleElement"
+            },
+            {
+              "required": [
+                "script"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "baseLifecycleElement": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "skipif": {
+              "type": "string",
+              "description": "The check to determine whether or not to run the script. You can define to check if an executable is on the path or if a file exists. If the output is true, then the AWS IoT Greengrass Core software skips the step.",
+              "default": "",
+              "pattern": "(onpath|exists)\\s+.*",
+              "examples": [
+                "exists /usr/local/bin/python3"
+              ]
+            },
+            "script": {
+              "type": "string",
+              "description": "The shell script to execute for this lifecycle",
+              "examples": [
+                "sudo apt-get install git"
+              ]
+            },
+            "requiresprivilege": {
+              "oneOf": [
+                {
+                  "type": "boolean",
+                  "description": "If set to true the script will be execute with root privileges",
+                  "default": false,
+                  "examples": [
+                    false
+                  ]
+                },
+                {
+                  "type": "string",
+                  "description": "If set to true the script will be execute with root privileges.",
+                  "default": "false",
+                  "examples": [
+                    "false"
+                  ]
+                }
+              ]
+            },
+            "setenv": {
+              "$ref": "#/definitions/setenv"
+            },
+            "timeout": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "description": "The maximum amount of time in seconds that the script can run before the AWS IoT Greengrass Core software terminates the process.",
+                  "default": 120,
+                  "examples": [
+                    120
+                  ]
+                },
+                {
+                  "type": "string",
+                  "description": "The maximum amount of time in seconds that the script can run before the AWS IoT Greengrass Core software terminates the process.",
+                  "default": "120",
+                  "examples": [
+                    "120"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "setenv": {
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "The Setenv schema",
+          "description": "Setting environment variable, which will be provided to the process executed by the lifecycle script",
+          "default": "{}",
+          "examples": [
+            {
+              "VAR_A": "10"
+            }
+          ],
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "selections": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "all"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "topLevelSelections": {
+      "properties": {
+        "all": {
+          "$ref": "#/definitions/lifecycle"
+        }
+      },
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/definitions/lifecycle"
+        }
+      }
+    },
+    "multiLevelSelections": {
+      "properties": {
+        "all": {
+          "$ref": "#/definitions/globalLifecycle"
+        }
+      },
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/definitions/globalLifecycle"
+        }
+      }
+    }
+  },
+  "properties": {
+    "recipeformatversion": {
+      "$id": "#/properties/RecipeFormatVersion",
+      "type": "string",
+      "title": "The RecipeFormatVersion schema",
+      "description": "",
+      "default": "2020-01-25",
+      "enum": [
+        "2020-01-25"
+      ],
+      "examples": [
+        {
+          "RecipeFormatVersion": "2020-01-25"
+        }
+      ]
+    },
+    "componentname": {
+      "$id": "#/properties/ComponentName",
+      "type": "string",
+      "title": "The ComponentName schema",
+      "description": "The name of the component",
+      "pattern": "^[a-zA-Z0-9-_.]+$",
+      "maxLength": 128,
+      "examples": [
+        "com.example.FooService"
+      ]
+    },
+    "componentdescription": {
+      "$id": "#/properties/ComponentDescription",
+      "type": "string",
+      "title": "The ComponentDescription schema",
+      "description": "The description of the component",
+      "default": "",
+      "examples": [
+        "Complete recipe for AWS IoT Greengrass components"
+      ]
+    },
+    "componentpublisher": {
+      "$id": "#/properties/ComponentPublisher",
+      "type": "string",
+      "title": "The ComponentPublisher schema",
+      "description": "The publisher of this component.",
+      "default": "Me"
+    },
+    "componentversion": {
+      "$id": "#/properties/ComponentVersion",
+      "type": "string",
+      "title": "The ComponentVersion schema",
+      "description": "",
+      "default": "1.0.0",
+      "maxLength": 64,
+      "examples": [
+        "1.0.0-alpha"
+      ]
+    },
+    "componentconfiguration": {
+      "$id": "#/properties/ComponentConfiguration",
+      "type": "object",
+      "title": "The ComponentConfiguration schema",
+      "description": "The default configuration for this component\nDefines arbitrary configuration objects and accessControl object",
+      "default": "{}",
+      "examples": [
+        {
+          "defaultconfiguration": {
+            "TestParam": "TestValue"
+          }
+        }
+      ],
+      "properties": {
+        "defaultconfiguration": {
+          "title": "The DefaultConfiguration schema",
+          "description": "Default configuration parameters for the component",
+          "default": "{}"
+        }
+      }
+    },
+    "componenttype": {
+      "$id": "#/properties/ComponentType",
+      "type": "string",
+      "title": "The ComponentType schema",
+      "description": "The type of this component.",
+      "default": "aws.greengrass.generic",
+      "enum": [
+        "aws.greengrass.nucleus",
+        "aws.greengrass.generic",
+        "aws.greengrass.plugin",
+        "aws.greengrass.lambda"
+      ]
+    },
+    "componentsource": {
+      "$id": "#/properties/ComponentSource",
+      "type": "string",
+      "title": "The ComponentSource schema",
+      "pattern": "^arn:aws(-(cn|us-gov|iso(-[a-z])?))?:lambda:.*$",
+      "description": "The lambda arn which is source of this component.",
+      "default": ""
+    },
+    "componentdependencies": {
+      "$id": "#/properties/ComponentDependencies",
+      "type": "object",
+      "title": "The ComponentDependencies schema",
+      "description": "Map describing the dependencies for this component",
+      "default": "{}",
+      "examples": [
+        {
+          "BarService": {
+            "versionrequirement": "^1.1.0",
+            "dependencytype": "SOFT"
+          },
+          "BazService": {
+            "versionrequirement": "^2.0.0"
+          }
+        }
+      ],
+      "patternProperties": {
+        "^[a-zA-Z0-9-_.]+$": {
+          "type": "object",
+          "title": "The dependency schema",
+          "description": "Dependency configuration for this component",
+          "default": {
+            "VersionRequirement": ">0.0.0"
+          },
+          "examples": [
+            {
+              "VersionRequirement": "^1.1.0",
+              "DependencyType": "SOFT"
+            }
+          ],
+          "required": [
+            "versionrequirement"
+          ],
+          "properties": {
+            "versionrequirement": {
+              "type": "string",
+              "title": "The VersionRequirement schema",
+              "description": "The version of the dependency",
+              "default": "",
+              "examples": [
+                "^1.1.0"
+              ]
+            },
+            "dependencytype": {
+              "type": "string",
+              "title": "The DependencyType schema",
+              "description": "The type of this dependency.",
+              "default": "HARD",
+              "enum": [
+                "SOFT",
+                "HARD"
+              ],
+              "examples": [
+                "SOFT"
+              ]
+            }
+          },
+          "additionalProperties": true
+        }
+      }
+    },
+    "manifests": {
+      "$id": "#/properties/Manifests",
+      "type": "array",
+      "title": "The Manifests schema",
+      "description": "List of manifests describing the component lifecycle and artifacts for specific platform",
+      "items": {
+        "$id": "#/properties/Manifests/items",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "platform": {
+            "type": "object",
+            "properties": {
+              "os": {
+                "type": "string"
+              },
+              "architecture": {
+                "type": "string"
+              }
+            },
+            "patternProperties": {
+              ".*": {
+                "type": "string"
+              }
+            }
+          },
+          "lifecycle": {
+            "$ref": "#/definitions/baseLifecycle"
+          },
+          "selections": {
+            "$ref": "#/definitions/selections"
+          },
+          "artifacts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "uri"
+              ],
+              "properties": {
+                "uri": {
+                  "type": "string"
+                },
+                "unarchive": {
+                  "type": "string",
+                  "default": "NONE",
+                  "enum": [
+                    "ZIP",
+                    "NONE"
+                  ]
+                },
+                "permission": {
+                  "type": "object",
+                  "examples": [
+                    {
+                      "read": "OWNER",
+                      "execute": "NONE"
+                    }
+                  ],
+                  "properties": {
+                    "read": {
+                      "$ref": "#/definitions/permissions"
+                    },
+                    "execute": {
+                      "$ref": "#/definitions/permissions"
+                    }
+                  }
+                },
+                "digest": {
+                  "type": "string",
+                  "description": "the digest of the component",
+                  "readOnly": true
+                },
+                "algorithm": {
+                  "type": "string",
+                  "description": "The hash algorithm that AWS IoT Greengrass uses to calculate the digest hash of the artifact",
+                  "readOnly": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "lifecycle": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/topLevelSelections"
+        },
+        {
+          "$ref": "#/definitions/globalLifecycle"
+        },
+        {
+          "$ref": "#/definitions/multiLevelSelections"
+        }
+      ]
+    }
+  },
+  "if": {
+    "not": {
+      "properties": {
+        "componenttype": {
+          "const": "aws.greengrass.plugin"
+        }
+      }
+    }
+  },
+  "then": {
+    "properties": {
+      "manifests": {
+        "items": {
+          "properties": {
+            "lifecycle": {
+              "$ref": "#/definitions/lifecycle"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/com/amazon/aws/iot/greengrass/component/common/RecipeSchemaTest.java
+++ b/src/test/java/com/amazon/aws/iot/greengrass/component/common/RecipeSchemaTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazon.aws.iot.greengrass.component.common;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import org.hamcrest.core.Is;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class RecipeSchemaTest extends BaseRecipeTest {
+
+    static JsonSchema jsonRecipeSchemaValidator;
+    static JsonSchema yamlRecipeSchemaValidator;
+
+    static ObjectMapper jsonObjectMapper = SerializerFactory.getRecipeSerializerJson();
+    static ObjectMapper yamlObjectMapper = SerializerFactory.getRecipeSerializer();
+
+    @BeforeAll
+    static void setupRecipeSchemaValidator() throws URISyntaxException, IOException {
+        Path recipePath = Paths.get(ComponentRecipe.class.getClassLoader()
+                .getResource("recipe").toURI()).resolve("recipe_schema.json");
+
+
+        String schemaString = new String(Files.readAllBytes(recipePath));
+
+        JsonSchemaFactory jsonFactory = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
+                .objectMapper(SerializerFactory.getRecipeSerializerJson()).build();
+
+        JsonSchemaFactory yamlFactory = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7))
+                .objectMapper(SerializerFactory.getRecipeSerializer()).build();
+
+        // any invalid json recipe schemas supplied will be caught here
+        jsonRecipeSchemaValidator = jsonFactory.getSchema(schemaString);
+        yamlRecipeSchemaValidator = yamlFactory.getSchema(schemaString);
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings= {
+            "b1-recipe-with-all-fields.yaml",
+            "sample-recipe-with-all-fields.yaml",
+            "sample-recipe-missing-permission-fields.yaml",
+            "wrapper-component-recipe.yaml"
+    })
+    void GIVEN_valid_yaml_recipe_WHEN_validate_THEN_return_success(String fileName)
+            throws IOException {
+
+        Path recipePath = getResourcePath(fileName);
+        String recipeString = new String(Files.readAllBytes(recipePath));
+
+        Set<ValidationMessage> messages = validateYamlRecipe(recipeString);
+        assertThat("Recipe validated successfully", messages.isEmpty(), Is.is(true));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings= {
+            "b2-recipe-with-all-fields.json",
+            "sample-recipe-with-all-fields.json",
+            "wrapper-component-recipe.json"
+    })
+    void GIVEN_valid_json_recipe_WHEN_validate_THEN_return_success(String fileName)
+            throws IOException {
+
+        Path recipePath = getResourcePath(fileName);
+        String recipeString = new String(Files.readAllBytes(recipePath));
+        Set<ValidationMessage> messages = validateJsonRecipe(recipeString);
+        assertThat("Recipe validated successfully", messages.isEmpty(), Is.is(true));
+    }
+
+    @Test
+    void GIVEN_recipe_missing_required_field_WHEN_validate_THEN_return_success()
+            throws IOException {
+        Path recipePath = getResourcePath("sample-recipe-fail-missing-uri.yaml");
+        String recipeString = new String(Files.readAllBytes(recipePath));
+        Set<ValidationMessage> messages = validateYamlRecipe(recipeString);
+        assertThat("Missing required URI caught", messages.toString().contains("uri: is missing"), Is.is(true));
+    }
+
+    @Test
+    void GIVEN_recipe_with_long_component_name_WHEN_validate_THEN_return_success()
+            throws IOException {
+        Path recipePath = getResourcePath("sample-recipe-with-long-component-version.yaml");
+        String recipeString = new String(Files.readAllBytes(recipePath));
+        Set<ValidationMessage> messages = validateYamlRecipe(recipeString);
+        assertThat("Missing required URI caught", messages.toString().contains("may only be 64 char"), Is.is(true));
+    }
+
+    private Set<ValidationMessage> validateYamlRecipe(String recipe) throws JsonProcessingException {
+        JsonNode recipeNode = yamlObjectMapper.readTree(recipe);
+        recipeNode = lowerJsonNodeKeys(recipeNode, yamlObjectMapper);
+        Set<ValidationMessage> messages = yamlRecipeSchemaValidator.validate(recipeNode);
+        if (!messages.isEmpty()) {
+            System.out.println(messages);
+        };
+        return messages;
+    }
+
+    private Set<ValidationMessage> validateJsonRecipe(String recipe) throws JsonProcessingException {
+        JsonNode recipeNode = jsonObjectMapper.readTree(recipe);
+        recipeNode = lowerJsonNodeKeys(recipeNode, jsonObjectMapper);
+        Set<ValidationMessage> messages = jsonRecipeSchemaValidator.validate(recipeNode);
+        if (!messages.isEmpty()) {
+            System.out.println(messages);
+        };
+        return messages;
+    }
+
+    /*
+    Perform basic preprocessing to lower all recipe keys, does not perform complete preprocessing which involves
+    converting recipe to ComponentRecipe object to normalize enums. We do not perform this here as this cannot be
+    enforced by json schema alone.
+     */
+    private static JsonNode lowerJsonNodeKeys(JsonNode node, ObjectMapper mapper) {
+        ObjectNode loweredNode = mapper.createObjectNode();
+        Iterator<String> fieldNames = node.fieldNames();
+
+        // return value if iterating over json primitives
+        if (!fieldNames.hasNext()) {
+            return node;
+        }
+
+        while (fieldNames.hasNext()) {
+            String currentName = fieldNames.next();
+            JsonNode currentValue = null;
+            if (node.get(currentName).isObject()) {
+                // checking for nestedNode in currentNode
+                JsonNode nestedNode = node.get(currentName);
+                currentValue = lowerJsonNodeKeys(nestedNode, mapper);
+            } else if (node.get(currentName).isArray()) {
+                ArrayNode arrayNode = mapper.createArrayNode();
+
+                for (int i = 0; i < node.get(currentName).size(); i++) {
+                    arrayNode.add(lowerJsonNodeKeys(node.get(currentName).get(i), mapper));
+                }
+                currentValue = arrayNode;
+            } else {
+                currentValue = node.get(currentName);
+            }
+            loweredNode.put(currentName.toLowerCase(Locale.ROOT), currentValue);
+        }
+        return loweredNode;
+    }
+}

--- a/src/test/resources/recipes/b2-recipe-with-all-fields.json
+++ b/src/test/resources/recipes/b2-recipe-with-all-fields.json
@@ -8,7 +8,7 @@
   "ComponentDependencies": {
     "BarService": {
       "VersionRequirement": "^1.1",
-      "DependencyType": "soft"
+      "DependencyType": "SOFT"
     },
     "BazService": {
       "VersionRequirement": "^2.0"

--- a/src/test/resources/recipes/sample-recipe-missing-permission-fields.yaml
+++ b/src/test/resources/recipes/sample-recipe-missing-permission-fields.yaml
@@ -8,7 +8,7 @@ ComponentType: aws.greengrass.plugin
 ComponentDependencies:
   BarService:
     VersionRequirement: ^1.1
-    DependencyType: soft
+    DependencyType: SOFT
   BazService:
     VersionRequirement: ^2.0
 ComponentConfiguration:

--- a/src/test/resources/recipes/sample-recipe-with-all-fields.json
+++ b/src/test/resources/recipes/sample-recipe-with-all-fields.json
@@ -8,7 +8,7 @@
   "ComponentDependencies": {
     "BarService": {
       "VersionRequirement": "^1.1",
-      "DependencyType": "soft"
+      "DependencyType": "SOFT"
     },
     "BazService": {
       "VersionRequirement": "^2.0"

--- a/src/test/resources/recipes/sample-recipe-with-all-fields.yaml
+++ b/src/test/resources/recipes/sample-recipe-with-all-fields.yaml
@@ -8,7 +8,7 @@ ComponentType: aws.greengrass.plugin
 ComponentDependencies:
   BarService:
     VersionRequirement: ^1.1
-    DependencyType: soft
+    DependencyType: SOFT
   BazService:
     VersionRequirement: ^2.0
 ComponentConfiguration:


### PR DESCRIPTION
**Issue #, if available:**
CODEX-34580

**Description of changes:**
1. Add recipe schema introduced from [gdk repo](https://github.com/aws-greengrass/aws-greengrass-gdk-cli/pull/259) here. 
2. Update recipe schema to convert Enum fieldsusing regex pattern back to enum (**Permissions**, **ComponentType**, **DependencyType**, **Unarchive**). These were changed to regex as json schema does not have capability of handling case-insensitive enums.

**Why is this change necessary:**
We want to put the recipe schema in a central location into this repo as Greengrass has workflows to automate intake of this repo into our internal code base for consumption.

For the recipe schema updates, we are converting back to using enums instead of regex ([GDK related commig](https://github.com/aws-greengrass/aws-greengrass-gdk-cli/pull/259/commits/4590dd5dfe23f13f736b440abff951b5bee3fa43)) which was initially made to workaround json schema not supporting case-insensitive enums. We are changing back to using enums as we now validate the serialized customer provided recipe (converted to ComponentRecipe) which normalizes values for the customer. This is also the recipe that gets saved internally and referenced by Greengrass. 

**How was this change tested:**
1. Tested internal intake of this schema onto Greengrass cloud services locally.
2. Recipe schema json changes were tested in personal stack using existing integration tests

**Any additional information or context required to review the change:**
Will need to followup with GDK side change to consume the recipe from this repo instead of storing local copy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
