### PR TITLE
feat(platform-runtime): add runtime as recognized key in Platform map

### DIFF
--- a/src/main/java/com/amazon/aws/iot/greengrass/component/common/Platform.java
+++ b/src/main/java/com/amazon/aws/iot/greengrass/component/common/Platform.java
@@ -31,6 +31,7 @@ public class Platform extends HashMap<String,String> {
     public static final Platform EMPTY = new Platform();
     public static final String OS_KEY = "os";
     public static final String ARCHITECTURE_KEY = "architecture";
+    public static final String RUNTIME_KEY = "runtime";
     public static final String WILDCARD = "*";
 
     /**
@@ -78,6 +79,14 @@ public class Platform extends HashMap<String,String> {
      */
     public String getArchitectureField() {
         return getFieldOrWild(ARCHITECTURE_KEY);
+    }
+
+    /**
+     * Retrieve Runtime, or Wildcard if Runtime not specified
+     * @return Runtime as a string with expected default.
+     */
+    public String getRuntimeField() {
+        return getFieldOrWild(RUNTIME_KEY);
     }
 
     /**
@@ -176,6 +185,10 @@ public class Platform extends HashMap<String,String> {
             } else {
                 return add(ARCHITECTURE_KEY, value.name);
             }
+        }
+
+        public PlatformBuilder runtime(String value) {
+            return add(RUNTIME_KEY, value);
         }
 
         public PlatformBuilder add(String name, String value) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add `runtime` as a recognized key in the Platform map. Also add builder methods to help build Platform map with runtime field populated as part of the ComponentRecipe.

**Why is this change necessary:**
This change simplifies the use of runtime field while building component recipes.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
